### PR TITLE
Change redirect url to /static/app/

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Getting started
 
 Note: Chrome 36+ is required.
 
-The application works by redirecting navigations to codereview.chromium.org to /app/ which
-the server will respond to with a 404. It then replaces the 404 page with the app. This
-is done since most rietveld pages take a long time to load, but the 404 page is fast.
+The application works by redirecting navigations to codereview.chromium.org to /static/app/
+which the server will respond to with a 404. It then replaces the 404 page with the app.
+This is done since most rietveld pages take a long time to load, but the 404 page is fast.

--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 
 var URL_PATTERN = /^https?:\/\/codereview.chromium.org\/(\d+)?\/?$/;
-var APP_URL = "https://codereview.chromium.org/app/";
+var APP_URL = "https://codereview.chromium.org/static/app/";
 
 chrome.webNavigation.onBeforeNavigate.addListener(function(details) {
     var url = details.url;

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
 
   "content_scripts": [
     {
-      "matches": ["https://codereview.chromium.org/app/*"],
+      "matches": ["https://codereview.chromium.org/static/app/*"],
       "js": [
         "ui/base.js",
         "ui/resources.js",


### PR DESCRIPTION
Rietveld serves /static/ using the app engine static content
service. This can generate a 404 faster because the request does
not require an instance.
