### PR TITLE
Use the WebRequest API to redirect requests to the extension.

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,12 +6,13 @@ var LEGACY_REDIRECT_URL_PATTERN = /^https:\/\/codereview.chromium.org\/static\/a
 var CHROMIUM_URL = "https://codereview.chromium.org";
 var APP_URL = "https://codereview.chromium.org/static/app/";
 
-chrome.webNavigation.onBeforeNavigate.addListener(function(details) {
+chrome.webRequest.onBeforeRequest.addListener(function(details) {
+    if (details.type != "main_frame" && details.type != "sub_frame")
+        return;
     var url = details.url;
     if (url.match(APPSPOT_URL_PATTERN)) {
         var url = url.replace(APPSPOT_URL_PATTERN, CHROMIUM_URL);
-        chrome.tabs.update(details.tabId, {url:url});
-        return;
+        return {redirectUrl: url};
     }
     var match = url.match(APP_REDIRECT_URL_PATTERN);
     if (!match)
@@ -19,10 +20,12 @@ chrome.webNavigation.onBeforeNavigate.addListener(function(details) {
     if (!match)
         return;
     var url = APP_URL + (match[1] || "");
-    chrome.tabs.update(details.tabId, {url:url});
+    return {redirectUrl: url};
 }, {
-    url: [
-        {hostEquals: "chromiumcodereview.appspot.com"},
-        {hostEquals: "codereview.chromium.org"},
+    urls: [
+        "*://chromiumcodereview.appspot.com/*",
+        "*://codereview.chromium.org/*"
     ]
-});
+}, [
+    "blocking"
+]);

--- a/manifest.json
+++ b/manifest.json
@@ -31,9 +31,9 @@
   ],
 
   "permissions": [
-    "https://codereview.chromium.org/*",
-    "http://codereview.chromium.org/*",
-    "webNavigation",
-    "tabs"
+    "*://chromiumcodereview.appspot.com/*",
+    "*://codereview.chromium.org/*",
+    "webRequest",
+    "webRequestBlocking"
   ]
 }


### PR DESCRIPTION
With the WebNavigation API, users could get stranded on an issue after
refreshing, since the extension redirect would leave an entry behind in
the history. WebRequest prevents this since it cancels the original
request from completing when it redirects.

Fixes #33
