### PR TITLE
Added the Base URL field

### DIFF
--- a/ui/components/cr-issue-meta.html
+++ b/ui/components/cr-issue-meta.html
@@ -75,6 +75,12 @@
                     </template>
                 </div>
             </div>
+            <div class="issue-base-url issue-meta-item">
+                <div class="issue-meta-type">Base URL</div>
+                <div class="issue-meta-value">
+                    {{ issue.baseUrl }}
+                </div>
+            </div>
         </template>
     </template>
     <script>


### PR DESCRIPTION
The Base URL field is useful for generally sifting through issues and understanding whether it is a Chromium issue, a Blink issue and so on.
Fixes https://github.com/esprehn/chromium-codereview/issues/47
